### PR TITLE
Latest ghc compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,10 @@ A nullary type class for partial functions
 Use the `Partial` type class to track your partial functions. For example:
 
 ```haskell
-{-# LANGUAGE NullaryTypeClasses #-}
-
 import Data.List.Partial
 
 cadr :: (Partial) => [a] -> a
-cadr = head . head
+cadr = head . tail
 ```
 
 As an application developer, either opt into partial functions globally by declaring an instance of the `Partial` type class:

--- a/src/Control/Partial.hs
+++ b/src/Control/Partial.hs
@@ -1,7 +1,10 @@
-{-# LANGUAGE Rank2Types #-}
-{-# LANGUAGE NullaryTypeClasses #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE RankNTypes #-}
 
-module Control.Partial where
+module Control.Partial
+  ( Partial
+  , partial
+  ) where
 
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -17,8 +20,12 @@ import Unsafe.Coerce (unsafeCoerce)
 class Partial
 
 -- |
+-- Newtype wrapper for partial function, to aid in type inference.
+--
+newtype Wrapper r = Wrapper ((Partial) => r)
+
+-- |
 -- This function can be used to evaluate a partial function
 --
 partial :: ((Partial) => r) -> r
-partial = ($ ()) . unsafeCoerce
-            
+partial f = unsafeCoerce (Wrapper f) ()


### PR DESCRIPTION
This makes the library build with the latest GHC, which did not like the `unsafeCoerce`ion of a higher-rank type. I don't know exactly which GHC version made it incompatible.